### PR TITLE
feat: updated section list to be tabbable

### DIFF
--- a/components/Nav.js
+++ b/components/Nav.js
@@ -18,8 +18,8 @@ export const Nav = ({ selectedSectionSlugs, setShowModal, getTemplate }) => {
   return (
     <nav className="flex justify-between p-4 bg-gray-800 align-center">
       <Link href="/">
-        <a className="flex items-center">
-          <img className="w-auto h-8 mt-1 cursor-pointer" src="readme.svg" />
+        <a className="focus:outline-none focus:ring-2 focus:ring-emerald-400 flex items-center">
+          <img className="w-auto h-8 mt-1" src="readme.svg" />
           <span className="ml-2 -mb-2 text-white logo text-md">readme.so</span>
         </a>
       </Link>
@@ -28,7 +28,7 @@ export const Nav = ({ selectedSectionSlugs, setShowModal, getTemplate }) => {
         className="relative inline-flex items-center px-4 py-2 text-sm font-bold tracking-wide text-white border border-transparent rounded-md shadow-sm bg-emerald-500 hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-emerald-500"
         onClick={downloadMarkdownFile}
       >
-        <img className="w-auto h-6 mr-2 cursor-pointer" src="download.svg" />
+        <img className="w-auto h-6 mr-2" src="download.svg" />
         <span>Download</span>
       </button>
     </nav>

--- a/components/SectionsColumn.js
+++ b/components/SectionsColumn.js
@@ -94,12 +94,14 @@ export const SectionsColumn = ({
         )}
         <ul className="mb-12 space-y-3">
           {sectionSlugs.map((s) => (
-            <li
-              onClick={(e) => onAddSection(e, s)}
-              key={s}
-              className="flex items-center py-2 pl-3 pr-6 bg-white rounded-md shadow cursor-pointer"
-            >
-              <p>{getTemplate(s).name}</p>
+            <li key={s}>
+              <button
+                className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-400 w-full h-full flex items-center py-2 pl-3 pr-6 bg-white rounded-md shadow cursor-pointer block"
+                type="button"
+                onClick={(e) => onAddSection(e, s)}
+              >
+                <span>{getTemplate(s).name}</span>
+              </button>
             </li>
           ))}
         </ul>

--- a/components/SortableItem.js
+++ b/components/SortableItem.js
@@ -17,20 +17,39 @@ export function SortableItem(props) {
     props.onDeleteSection(e, props.section.slug)
   }
 
+  const onKeyUp = (e) => {
+    if (e.key.toLowerCase() === 'enter') {
+      onClickSection()
+    }
+  }
+
   return (
     <li
       ref={setNodeRef}
       style={style}
       {...attributes}
       onClick={onClickSection}
-      className={`bg-white shadow rounded-md pl-3 pr-6 py-2 flex items-center cursor-pointer focus:outline-none relative  ${
+      onKeyUp={onKeyUp}
+      className={`bg-white shadow rounded-md pl-3 pr-6 py-2 flex items-center cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-400 relative  ${
         props.section.slug === props.focusedSectionSlug ? 'ring-2 ring-emerald-400' : ''
       }`}
     >
-      <img className="w-5 h-5 mr-2" src="drag.svg" {...listeners} />
+      <button
+        type="button"
+        className="mr-2 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-400"
+        {...listeners}
+      >
+        <img className="w-5 h-5" src="drag.svg" />
+      </button>
       <p>{props.section.name}</p>
       {props.section.slug === props.focusedSectionSlug && (
-        <img onClick={onClickTrash} className="absolute w-auto h-5 right-2" src="trash.svg" />
+        <button
+          className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-400 absolute right-2"
+          type="button"
+          onClick={onClickTrash}
+        >
+          <img className="w-auto h-5" src="trash.svg" alt="" />
+        </button>
       )}
     </li>
   )


### PR DESCRIPTION
* Updated sections list to be tabbable by wrapping the content inside a button
* Put the delete icon inside a button to allow for tabbing
* Wrapped the drag and drop icon inside a button and attached the drag and drop listeners to it
* * This way you can use the up and down arrow keys to sort

https://github.com/katherinepeterson/readme.so/issues/27