### PR TITLE
Alphabetize sectionSlugs to normalize render of possible sections

### DIFF
--- a/components/SectionsColumn.js
+++ b/components/SectionsColumn.js
@@ -57,6 +57,8 @@ export const SectionsColumn = ({
     setFocusedSectionSlug(null)
   }
 
+  const alphabetizedSectionSlugs = sectionSlugs.sort()
+
   return (
     <div className="sections">
       <h3 className="text-lg leading-6 font-medium text-gray-900 mb-3">Sections</h3>
@@ -93,7 +95,7 @@ export const SectionsColumn = ({
           </h4>
         )}
         <ul className="mb-12 space-y-3">
-          {sectionSlugs.map((s) => (
+          {alphabetizedSectionSlugs.map((s) => (
             <li key={s}>
               <button
                 className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-400 w-full h-full flex items-center py-2 pl-3 pr-6 bg-white rounded-md shadow cursor-pointer block"


### PR DESCRIPTION
### Objective
Normalize the UX for adding and removing sections from your readme. 

### Changes
This pull request simply alphabetizes the section list on render so that whenever a section is either selected or removed, it always appears in the same spot on the list.

|Before|After| 
|---|---|
|![readme-original](https://user-images.githubusercontent.com/47455758/114888635-0bff3d80-9dcf-11eb-8544-9f417560750f.jpg)|![readme-alphabetized](https://user-images.githubusercontent.com/47455758/114888659-115c8800-9dcf-11eb-8e49-a0e60174edbe.jpg)|










### Code Before
```javascript
<ul className="mb-12 space-y-3">
          {sectionSlugs.map((s) => (
            <li key={s}>
              <button
                className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-400 w-full h-full flex items-center py-2 pl-3 pr-6 bg-white rounded-md shadow cursor-pointer block"
                type="button"
                onClick={(e) => onAddSection(e, s)}
              >
                <span>{getTemplate(s).name}</span>
              </button>
            </li>
          ))}
        </ul>
```

### Code Changes
```javascript
const alphabetizedSectionSlugs = sectionSlugs.sort()

<ul className="mb-12 space-y-3">
          {alphabetizedSectionSlugs.map((s) => (
            <li key={s}>
              <button
                className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-400 w-full h-full flex items-center py-2 pl-3 pr-6 bg-white rounded-md shadow cursor-pointer block"
                type="button"
                onClick={(e) => onAddSection(e, s)}
              >
                <span>{getTemplate(s).name}</span>
              </button>
            </li>
          ))}
        </ul>
```

### Loom Before

https://user-images.githubusercontent.com/47455758/114888002-81b6d980-9dce-11eb-9425-93a9c9f8f751.mp4

### Loom After

https://user-images.githubusercontent.com/47455758/114888042-88455100-9dce-11eb-818f-e78ec506062b.mp4




