### PR TITLE
fix: Remove unused/unnecessary bit of code.

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -104,7 +104,7 @@ export default function Home() {
                 <div className="flex flex-col items-center">
                   <span className="inline-flex rounded-md shadow ">
                     <Link href="/editor">
-                      <a className="inline-flex items-center px-4 py-2 text-base font-medium text-xl bg-emerald-500 hover:bg-emerald-400 border border-transparent rounded-lg text-white w-[250px] h-[54px] justify-center">
+                      <a className="inline-flex items-center px-4 py-2 font-medium text-xl bg-emerald-500 hover:bg-emerald-400 border border-transparent rounded-lg text-white w-[250px] h-[54px] justify-center">
                         Get Started
                       </a>
                     </Link>


### PR DESCRIPTION
I have removed `text-base` because `text-lg` is written after `text-base` that's means it won't work and there is no reason to stay there.
If you have Tailwind CSS IntelliSense vs code extension you will realise that the extension is sending a warning.