### PR TITLE
Security: Third-party script loaded without integrity pinning (BuyMeACoffee widget)

### DIFF
--- a/pages/editor.js
+++ b/pages/editor.js
@@ -38,18 +38,6 @@ export default function Editor() {
       <Head>
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link href="https://fonts.googleapis.com/css2?family=Mali&display=swap" rel="stylesheet" />
-        <script
-          data-name="BMC-Widget"
-          data-cfasync="false"
-          src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js"
-          data-id="katherinecodes"
-          data-description="Support me on Buy me a coffee!"
-          data-message=""
-          data-color="#FFDD00"
-          data-position="Right"
-          data-x_margin="18"
-          data-y_margin="18"
-        ></script>
       </Head>
 
       <Nav


### PR DESCRIPTION
## Problem

The editor page loads a remote script from `https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js` directly in `<Head>`. If that CDN asset is tampered with, arbitrary JavaScript executes in the application origin, enabling full client-side compromise.

**Severity**: `high`
**File**: `pages/editor.js`

## Solution

Avoid third-party script execution in the main origin where possible. If required, self-host and pin a reviewed version, enforce a strict Content Security Policy, and add Subresource Integrity (`integrity` + `crossOrigin`) where supported. Consider lazy-loading in an isolated sandboxed iframe instead of direct execution.

## Changes

- `pages/editor.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
