### PR TITLE
i18n: add Korean (ko) translation

### DIFF
--- a/components/LanguageDropDown.js
+++ b/components/LanguageDropDown.js
@@ -81,6 +81,10 @@ export const languageSupports = [
     label: "O'zbekcha",
     route: '/uz',
   },
+  {
+    label: '한국어',
+    route: '/ko',
+  },
 ]
 
 export function LanguageDropDown({ posts }) {

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -21,6 +21,7 @@ module.exports = {
       'cn',
       'ru',
       'uz',
+      'ko',
     ],
   },
 }

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -1,0 +1,10 @@
+{
+  "title": "가장 쉽게 만드는",
+  "readme": "README",
+  "description": "간단한 에디터로 프로젝트에 필요한 모든 섹션을 빠르게 추가하고 원하는 대로 편집할 수 있습니다",
+  "get-started": "시작하기",
+  "made-with-love": "사랑을 담아 ",
+  "by": " 제작 ",
+  "language": "언어",
+  "translation-error": "번역이 어색한가요?"
+}

--- a/public/locales/ko/editor.json
+++ b/public/locales/ko/editor.json
@@ -1,0 +1,18 @@
+{
+  "editor-desktop-optimized": "이 사이트는 데스크톱에 최적화되어 있습니다",
+  "editor-visit-desktop": "README를 작성하려면 데스크톱에서 readme.so에 접속해 주세요!",
+  "nav-download": "다운로드",
+  "download-readme-generated": "Readme가 생성되었습니다!",
+  "download-reach-out": "readme.so를 이용해 주셔서 감사합니다! 편하게 연락 주세요",
+  "download-feedback": "어떤 의견이든 환영합니다.",
+  "download-coffee": "이 제품이 도움이 되셨다면 커피 한 잔으로 후원을 고려해 주세요!",
+  "editor-column-editor": "에디터",
+  "editor-select": "왼쪽 사이드바에서 섹션을 선택하면 내용을 편집할 수 있습니다",
+  "preview-column-preview": "미리보기",
+  "preview-column-raw": "원본",
+  "section-column-section": "섹션",
+  "section-column-click-edit": "아래 섹션을 클릭하면 내용을 편집할 수 있습니다",
+  "section-column-click-add": "아래 섹션을 클릭하면 README에 추가됩니다",
+  "section-column-click-reset": "초기화",
+  "custom-section": "사용자 지정 섹션"
+}


### PR DESCRIPTION
# Korean (ko) translation PR body template

## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.

한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.

## Changes

- Add `public/locales/ko/common.json` (8 keys, full parity with `en/common.json`)
- Add `public/locales/ko/editor.json` (16 keys, full parity with `en/editor.json`)
- Register `ko` in `next-i18next.config.js`
- Add the `한국어` entry to the language switcher in `components/LanguageDropDown.js`

## Testing

- Verified key parity: 24/24 keys match the current `en` locale exactly (no missing/extra keys)
- Kept "README" as a literal brand term, matching the convention used by every other locale
- Followed the same two-file-per-locale pattern used by all existing locales (e.g. `ja`, `cn`)

## Note on process

I didn't open an issue first — following the precedent of essentially every other
locale-addition PR in this repo (Japanese #126, Chinese #233, Uzbek #237, Arabic #207,
Russian #232, and many more), which were all merged directly without a prior issue.
Happy to open one retroactively if maintainers prefer that for future translation PRs.
